### PR TITLE
Fix case formatting

### DIFF
--- a/src/app/services/rule.service.ts
+++ b/src/app/services/rule.service.ts
@@ -358,7 +358,8 @@ export class RuleService {
         } else {
           logicExpr = { "==": [{ var: field }, value] }; // Fallback to equals if value format is incorrect
         }
-        break;default:
+        break;
+      default:
         logicExpr = { "==": [{ var: field }, value] };
     }
     


### PR DESCRIPTION
## Summary
- split `break;default:` into separate lines in `rule.service.ts`

## Testing
- `npm install`
- `npm run build` *(fails: bundle initial exceeded maximum budget)*

------
https://chatgpt.com/codex/tasks/task_e_685a6e71a76c8331822b580932362aa0