### PR TITLE
Add sidebar layout after login

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -19,9 +19,12 @@
   </div>
   
   <!-- Main Content -->
-  <div class="flex-grow-1">
-    <!-- Router Outlet - Components will be rendered here based on the current route -->
-    <router-outlet></router-outlet>
+  <div class="flex flex-grow-1">
+    <app-sidebar *ngIf="isAuthenticated" class="hidden md:block w-60 border-right-1 border-gray-200"></app-sidebar>
+    <div class="flex-grow p-3">
+      <!-- Router Outlet - Components will be rendered here based on the current route -->
+      <router-outlet></router-outlet>
+    </div>
   </div>
   
   <!-- Footer -->

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,8 @@ import { AppComponent } from './app.component';
 import { RuleBuilderComponent } from './components/rule-builder/rule-builder.component.supabase';
 import { LoginComponent } from './components/auth/login/login.component';
 import { RegisterComponent } from './components/auth/register/register.component';
+import { SidebarComponent } from './components/sidebar/sidebar.component';
+import { SimulationPanelComponent } from './components/simulation/simulation-panel.component';
 
 // Services
 import { SupabaseService } from './services/supabase.service';
@@ -72,7 +74,9 @@ import { AuthGuard } from './guards/auth.guard';
     // Standalone Components
     LoginComponent,
     RegisterComponent,
-    RuleBuilderComponent
+    RuleBuilderComponent,
+    SidebarComponent,
+    SimulationPanelComponent
   ],
   providers: [
     SupabaseService,


### PR DESCRIPTION
## Summary
- include sidebar and simulation panel modules
- add sidebar layout in root component to show lifecycle stages

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685a76ceca508331b216f64301c18677